### PR TITLE
feat(scroll): adding ability to scroll

### DIFF
--- a/src/PinchZoom/component.js
+++ b/src/PinchZoom/component.js
@@ -181,6 +181,19 @@ class PinchZoom extends Component<Props> {
     this._realizeInertia();
   }
 
+  _handleScroll(wheelEvent) {
+    const deltaY = wheelEvent.deltaY;
+    const deltaX = wheelEvent.deltaX;
+
+    this._addOffset({
+      x: deltaX,
+      y: deltaY
+    });
+
+    this._offset = this._sanitizeOffset(this._offset);
+    this._update();
+  }
+
   _handleZoomStart() {
     this.props.onZoomStart();
     this._stopAnimation();
@@ -804,6 +817,7 @@ class PinchZoom extends Component<Props> {
 
   _handlerWheel = (wheelEvent: WheelEvent) => {
     if (this.props.shouldInterceptWheel(wheelEvent)) {
+      this._handleScroll(wheelEvent);
       return;
     }
 


### PR DESCRIPTION
Might need some guidance on how best to fit this in. The default behaviour of the `shouldInterceptWheel` prop detects whether scaling should occur. If this function returns false, `_handlerWheel()` currently returns. This PR adds scrolling behaviour in this instance, which is what I'd expect with a two-finger scroll gesture on a trackpad

#10 
