### PR TITLE
Export public API types

### DIFF
--- a/src/PinchZoom/types.ts
+++ b/src/PinchZoom/types.ts
@@ -48,13 +48,7 @@ export interface DefaultProps {
   _document: Document;
 }
 
-export interface NonDefaultProps {
+export interface Props extends DefaultProps {
   onUpdate: (updateAction: UpdateAction) => void;
   children: JSX.Element;
 }
-
-// For internal use
-export type Props = NonDefaultProps & DefaultProps;
-
-// For external use
-export type PinchZoomProps = NonDefaultProps & Partial<DefaultProps>;

--- a/src/PinchZoom/types.ts
+++ b/src/PinchZoom/types.ts
@@ -48,7 +48,13 @@ export interface DefaultProps {
   _document: Document;
 }
 
-export interface Props extends DefaultProps {
+export interface NonDefaultProps {
   onUpdate: (updateAction: UpdateAction) => void;
   children: JSX.Element;
 }
+
+// For internal use
+export type Props = NonDefaultProps & DefaultProps;
+
+// For external use
+export type PinchZoomProps = NonDefaultProps & Partial<DefaultProps>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import type PinchZoomComp from './PinchZoom/component';
+
 export { default } from './PinchZoom/component';
 export {
   hasTranslate3DSupport,
@@ -6,8 +8,9 @@ export {
   isTouch,
 } from './utils';
 
-export type {
-  PinchZoomProps,
-  UpdateAction,
-  ScaleToOptions,
-} from './PinchZoom/types';
+export type { UpdateAction, ScaleToOptions } from './PinchZoom/types';
+
+export type PinchZoomProps = JSX.LibraryManagedAttributes<
+  typeof PinchZoomComp,
+  React.ComponentProps<typeof PinchZoomComp>
+>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,9 @@ export {
   make3dTransformValue,
   isTouch,
 } from './utils';
+
+export type {
+  PinchZoomProps,
+  UpdateAction,
+  ScaleToOptions,
+} from './PinchZoom/types';


### PR DESCRIPTION
This exports types which are part of public APIs. The component props type requires a separate type because on how `defaultProps` is treated on components.