### PR TITLE
Allow disabling double tap

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -124,6 +124,8 @@ This ratio indicate how fast the zoom will change when scrolling over the elemen
 
 Zoom factor that will be added for current zoom Factor when a double tap zooms to.
 
+A value of `0` will disable double tap handling.
+
 (default `1`)
 
 ## `zoomOutFactor?: number`

--- a/src/PinchZoom/component.tsx
+++ b/src/PinchZoom/component.tsx
@@ -284,7 +284,7 @@ class PinchZoom extends React.Component<Props> {
   }
 
   private _handleDoubleTap(event: TouchEvent) {
-    if (this._hasInteraction) {
+    if (this._hasInteraction || this.props.tapZoomFactor === 0) {
       return;
     }
 


### PR DESCRIPTION
Currently, double tap handling is always active and prevents double taps from passing through to the zoomable element. Passing `tapZoomFactor={0}` prevents double tap from zooming but still intercepts the second tap.

This change allows `tapZoomFactor={0}` to disable double tap handling entirely so that the zoomable element can receive double taps.