### PR TITLE
Append overflow option to props

### DIFF
--- a/src/PinchZoom/component.tsx
+++ b/src/PinchZoom/component.tsx
@@ -115,6 +115,7 @@ class PinchZoom extends React.Component<Props> {
     lockDragAxis: false,
     maxZoom: 5,
     minZoom: 0.5,
+    overflow: false,
     onDoubleTap: noup,
     onDragEnd: noup,
     onDragStart: noup,
@@ -808,16 +809,10 @@ class PinchZoom extends React.Component<Props> {
 
       if (
         this.props.shouldCancelHandledTouchEndEvents &&
-        (
-          isZoomInteraction(this._interaction) ||
-          (
-            isDragInteraction(this._interaction) &&
-            (
-              this._startOffset.x !== this._offset.x ||
-              this._startOffset.y !== this._offset.y
-            )
-          )
-        )
+        (isZoomInteraction(this._interaction) ||
+          (isDragInteraction(this._interaction) &&
+            (this._startOffset.x !== this._offset.x ||
+              this._startOffset.y !== this._offset.y)))
       ) {
         cancelEvent(touchEndEvent);
       }
@@ -987,7 +982,7 @@ class PinchZoom extends React.Component<Props> {
 
     return (
       <>
-        <style>{styles}</style>
+        <style>{styles({ overflow: this.props.overflow })}</style>
         <div
           {...props}
           ref={this._containerRef}
@@ -1018,6 +1013,7 @@ if (process.env.NODE_ENV !== 'production') {
     onUpdate: func.isRequired,
     maxZoom: number,
     minZoom: number,
+    overflow: bool,
     onDoubleTap: func,
     onDragEnd: func,
     onDragStart: func,

--- a/src/PinchZoom/styles.css.ts
+++ b/src/PinchZoom/styles.css.ts
@@ -1,4 +1,9 @@
+import { Props } from './types';
+
 export const styleRoot = 'kvfysmfp';
 export const styleChild = 'ufhsfnkm';
 
-export const styles = `.${styleRoot}{overflow:hidden;touch-action:none}.${styleChild}{transform-origin: 0 0}`;
+export const styles = ({ overflow }: Pick<Props, 'overflow'>) =>
+  `.${styleRoot}{overflow:${
+    overflow ? 'visible' : 'hidden'
+  };touch-action:none}.${styleChild}{transform-origin: 0 0}`;

--- a/src/PinchZoom/types.ts
+++ b/src/PinchZoom/types.ts
@@ -35,6 +35,7 @@ export interface DefaultProps {
 
   maxZoom: number;
   minZoom: number;
+  overflow: boolean;
   onDoubleTap: () => void;
   onDragEnd: () => void;
   onDragStart: () => void;


### PR DESCRIPTION
Hello there

I'm using your project with love.

when I using this project, I thought it would be nice to have `overflow` props for `wrapper div`.

So I append `overflow` option to `PinchZoom` component.

### as is

https://github.com/retyui/react-quick-pinch-zoom/blob/d5615059cabb8563ab04e9df7c6f41fe04425b77/src/PinchZoom/component.tsx#L990-L995

always `overflow: hidden` at this `div`

### to be

So I append `overflow` option (boolean type).

and handle this at styles (convert to function) d6b464125192ab9f92f8fce4a79f97baefdbdc6f

### more type for `overflow`?

I think `overflow` option can define to below type.

```ts
overflow: boolean | 'x' | 'y';

// 'x' will be
// overflow-x: visible;
// oveflow-y: hidden;
```

What do you think about it?

