### PR TITLE
Add prop to prevent moving child out of bounds while zooming

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -16,6 +16,7 @@
   - [`animationDuration`](#animationduration)
   - [`maxZoom?: number`](#maxzoom-number)
   - [`minZoom?: number`](#minzoom-number)
+  - [`enforceBoundsDuringZoom?: boolean`](#enforceboundsduringzoom-boolean)
   - [`draggableUnZoomed?: boolean`](#draggableunzoomed-boolean)
   - [`lockDragAxis?: boolean`](#lockdragaxis-boolean)
   - [`setOffsetsOnce?: boolean`](#setoffsetsonce-boolean)
@@ -53,6 +54,7 @@ import QuickPinchZoom from "react-quick-pinch-zoom";
   animationDuration={250}
   maxZoom={5}
   minZoom={0.5}
+  enforceBoundsDuringZoom={false}
   draggableUnZoomed={true}
   lockDragAxis={false}
   setOffsetsOnce={false}
@@ -161,6 +163,13 @@ Maximum zoom factor. (default `5`)
 ## `minZoom?: number`
 
 Minimum zoom factor. (default `0.5`)
+
+## `enforceBoundsDuringZoom?: boolean`
+
+While zooming, do not allow moving image to positions it cannot be
+dragged to.
+
+(default `false`)
 
 ## `draggableUnZoomed?: boolean`
 

--- a/example/src/data.js
+++ b/example/src/data.js
@@ -20,6 +20,11 @@ const demos = [
     component: () => import("./methods/DifferentScaleToAndAlignCenter")
   },
   {
+    id: "prop-enforceBoundsDuringZoom",
+    title: "enforceBoundsDuringZoom",
+    component: () => import("./props/EnforceBoundsDuringZoom")
+  },
+  {
     id: "prop-lockDragAxis",
     title: "lockDragAxis",
     component: () => import("./props/LockDragAxis")

--- a/example/src/props/EnforceBoundsDuringZoom/index.js
+++ b/example/src/props/EnforceBoundsDuringZoom/index.js
@@ -1,0 +1,45 @@
+import React, { Component, Fragment } from "react";
+
+import Base from "../../components/Base";
+import SvgGrid from "../../components/SvgGrid";
+
+const min = Math.min(window.innerWidth, window.innerHeight);
+const width = min;
+const height = min;
+const cellSize = 100;
+
+const containerProps = {
+  className: "border-container display-inline-block reset-line-height"
+};
+
+export default class EnforceBoundsDuringZoom extends Component {
+  renderChild = ({ innerRef, ...props }) => (
+    <SvgGrid
+      ref={innerRef}
+      {...props}
+      {...{
+        width,
+        height,
+        cellSize
+      }}
+      cols={width / cellSize}
+      rows={height / cellSize}
+      viewBox={`0 0 ${width} ${height}`}
+    />
+  );
+
+  render() {
+    return (
+      <Fragment>
+        <p>Prevent moving child out of bounds with pinch gesture:</p>
+        <pre>{`<QuickPinchZoom enforceBoundsDuringZoom />`}</pre>
+        <Base
+          enforceBoundsDuringZoom
+          containerProps={containerProps}
+          ref={this.quickPinchZoomRef}
+          Child={this.renderChild}
+        />
+      </Fragment>
+    );
+  }
+}

--- a/src/PinchZoom/component.tsx
+++ b/src/PinchZoom/component.tsx
@@ -107,6 +107,7 @@ class PinchZoom extends React.Component<Props> {
   static defaultProps: DefaultProps = {
     animationDuration: 250,
     draggableUnZoomed: true,
+    enforceBoundsDuringZoom: false,
     enabled: true,
     inertia: true,
     inertiaFriction: 0.96,
@@ -282,6 +283,10 @@ class PinchZoom extends React.Component<Props> {
     if (this._nthZoom > 3) {
       this._scale(scale, touchCenter);
       this._drag(touchCenter, this._lastZoomCenter);
+
+      if (this.props.enforceBoundsDuringZoom) {
+        this._offset = this._sanitizeOffset(this._offset);
+      }
     }
 
     this._lastZoomCenter = touchCenter;
@@ -1046,6 +1051,7 @@ if (process.env.NODE_ENV !== 'production') {
     wheelScaleFactor: number,
     animationDuration: number,
     draggableUnZoomed: bool,
+    enforceBoundsDuringZoom: bool,
     enabled: bool,
     horizontalPadding: number,
     lockDragAxis: bool,

--- a/src/PinchZoom/types.ts
+++ b/src/PinchZoom/types.ts
@@ -27,6 +27,7 @@ export interface DefaultProps {
   animationDuration: number;
   wheelScaleFactor: number;
   draggableUnZoomed: boolean;
+  enforceBoundsDuringZoom: boolean;
   inertia: boolean;
   inertiaFriction: number;
   enabled: boolean;


### PR DESCRIPTION
While dragging it is not possible to move the image to an "insane" offset (since `_sanitizeOffset` is called in `_handleDrag`). This prop ensures that it's also not possible to move the image out of bounds with a pinch gesture.

Without prop:

https://github.com/retyui/react-quick-pinch-zoom/assets/26554/78a311f1-eaac-465f-b789-0bd6567d7679

With prop:

https://github.com/retyui/react-quick-pinch-zoom/assets/26554/5e8955aa-74dd-40fe-b8b7-afd227892488



