### PR TITLE
Add prop to prevent moving child that is smaller than container 

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,10 +1,10 @@
 [
   {
     "limit": "16500 B",
-    "path": "cmj/**/*.js"
+    "path": ["cmj/**/*.js", "!cmj/**/__tests__/*.js"]
   },
   {
     "limit": "16500 B",
-    "path": "esm/**/*.js"
+    "path": ["esm/**/*.js", "!esm/**/__tests__/*.js"]
   }
 ]

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -17,6 +17,7 @@
   - [`maxZoom?: number`](#maxzoom-number)
   - [`minZoom?: number`](#minzoom-number)
   - [`enforceBoundsDuringZoom?: boolean`](#enforceboundsduringzoom-boolean)
+  - [`centerContained?: boolean`](#centercontained-boolean)
   - [`draggableUnZoomed?: boolean`](#draggableunzoomed-boolean)
   - [`doubleTapZoomOutOnMaxScale`](#doubletapzoomoutonmaxscale-boolean)
   - [`doubleTapToggleZoom`](#doubletaptogglezoom-boolean)
@@ -57,6 +58,7 @@ import QuickPinchZoom from "react-quick-pinch-zoom";
   maxZoom={5}
   minZoom={0.5}
   enforceBoundsDuringZoom={false}
+  centerContained={false}
   draggableUnZoomed={true}
   doubleTapZoomOutOnMaxScale={false}
   doubleTapToggleZoom={false}
@@ -179,6 +181,14 @@ Minimum zoom factor. (default `0.5`)
 
 While zooming, do not allow moving image to positions it cannot be
 dragged to.
+
+(default `false`)
+
+## `centerContained?: boolean`
+
+Center image, when it does not cover that container (e.g., when the
+container has a fixed size or when the image is scaled down below its
+initial size using a pinch gesture).
 
 (default `false`)
 

--- a/example/src/data.js
+++ b/example/src/data.js
@@ -25,6 +25,11 @@ const demos = [
     component: () => import("./props/EnforceBoundsDuringZoom")
   },
   {
+    id: "prop-centerContained",
+    title: "centerContained",
+    component: () => import("./props/CenterContained")
+  },
+  {
     id: "prop-lockDragAxis",
     title: "lockDragAxis",
     component: () => import("./props/LockDragAxis")

--- a/example/src/props/CenterContained/index.js
+++ b/example/src/props/CenterContained/index.js
@@ -1,0 +1,59 @@
+import React, { Component, Fragment } from "react";
+
+import Base from "../../components/Base";
+import SvgGrid from "../../components/SvgGrid";
+
+const min = Math.min(window.innerWidth, window.innerHeight);
+const width = min;
+const height = min;
+const cellSize = 100;
+
+const containerProps = {
+  style: {height: '80vh'},
+  className: "border-container display-inline-block reset-line-height"
+};
+
+export default class CenterContained extends Component {
+  renderChild = ({ innerRef, ...props }) => (
+    <SvgGrid
+      ref={innerRef}
+      {...props}
+      {...{
+        width,
+        height,
+        cellSize
+      }}
+      cols={width / cellSize}
+      rows={height / cellSize}
+      viewBox={`0 0 ${width} ${height}`}
+    />
+  );
+
+  render() {
+    return (
+      <Fragment>
+        <p>Do not allow moving child out of center when it does not cover the container.</p>
+        <pre>{`<QuickPinchZoom centerContained />`}</pre>
+        <Base
+          centerContained
+          containerProps={containerProps}
+          ref={this.quickPinchZoomRef}
+          Child={this.renderChild}
+        />
+
+        <p>Works best in combination with enforceBoundsDuringZoom to make
+          sure the child stays centered during zoom.</p>
+        <pre>
+          {`<QuickPinchZoom \n  centerContained enforceBoundsDuringZoom />`}
+        </pre>
+        <Base
+          centerContained
+          enforceBoundsDuringZoom
+          containerProps={containerProps}
+          ref={this.quickPinchZoomRef}
+          Child={this.renderChild}
+        />
+      </Fragment>
+    );
+  }
+}

--- a/src/PinchZoom/__tests__/getOffsetBounds.test.js
+++ b/src/PinchZoom/__tests__/getOffsetBounds.test.js
@@ -88,4 +88,102 @@ describe('getOffsetBounds', () => {
     expect(min).toEqual(-20);
     expect(max).toEqual(10);
   });
+
+  describe('with centerContained option', () => {
+    it('allows no movement when container and child have same dimension', () => {
+      const [min, max] = getOffsetBounds({
+        containerDimension: 100,
+        childDimension: 100,
+        padding: 0,
+        centerContained: true
+      });
+
+      expect(min).toEqual(0);
+      expect(max).toEqual(0);
+    });
+
+    it('ensures child that is larger than container always covers container', () => {
+      const [min, max] = getOffsetBounds({
+        containerDimension: 100,
+        childDimension: 150,
+        padding: 0,
+        centerContained: true
+      });
+
+      expect(min).toEqual(0);
+      expect(max).toEqual(50);
+    });
+
+    it('does not allow moving child that is smaller than container out of center', () => {
+      const [min, max] = getOffsetBounds({
+        containerDimension: 200,
+        childDimension: 100,
+        padding: 0,
+        centerContained: true
+      });
+
+      expect(min).toEqual(-50);
+      expect(max).toEqual(-50);
+    });
+
+    it('allows moving far enough to reveal padding', () => {
+      const [min, max] = getOffsetBounds({
+        containerDimension: 100,
+        childDimension: 150,
+        padding: 10,
+        centerContained: true
+      });
+
+      expect(min).toEqual(-10);
+      expect(max).toEqual(60);
+    });
+
+    it('allows revealing padding even if container and child have same dimension', () => {
+      const [min, max] = getOffsetBounds({
+        containerDimension: 100,
+        childDimension: 100,
+        padding: 10,
+        centerContained: true
+      });
+
+      expect(min).toEqual(-10);
+      expect(max).toEqual(10);
+    });
+
+    it('ignores padding if child including padding is smaller than container', () => {
+      const [min, max] = getOffsetBounds({
+        containerDimension: 200,
+        childDimension: 100,
+        padding: 10,
+        centerContained: true
+      });
+
+      expect(min).toEqual(-50);
+      expect(max).toEqual(-50);
+    });
+
+    it('allows revealing padding even if child and one padding fits container', () => {
+      const [min, max] = getOffsetBounds({
+        containerDimension: 200,
+        childDimension: 190,
+        padding: 10,
+        centerContained: true
+      });
+
+      expect(min).toEqual(-10);
+      expect(max).toEqual(0);
+    });
+
+    it('allows revealing padding even if child without padding is smaller than container', () => {
+      const [min, max] = getOffsetBounds({
+        containerDimension: 200,
+        childDimension: 190,
+        padding: 20,
+        centerContained: true
+      });
+
+      expect(min).toEqual(-20);
+      expect(max).toEqual(10);
+    });
+  })
 });

--- a/src/PinchZoom/__tests__/getOffsetBounds.test.js
+++ b/src/PinchZoom/__tests__/getOffsetBounds.test.js
@@ -1,0 +1,91 @@
+import { getOffsetBounds } from '../getOffsetBounds';
+
+describe('getOffsetBounds', () => {
+  it('allows no movement when container and child have same dimension', () => {
+    const [min, max] = getOffsetBounds({
+      containerDimension: 100,
+      childDimension: 100,
+      padding: 0
+    });
+
+    expect(min).toEqual(0);
+    expect(max).toEqual(0);
+  });
+
+  it('ensures child that is larger than container always covers container', () => {
+    const [min, max] = getOffsetBounds({
+      containerDimension: 100,
+      childDimension: 150,
+      padding: 0
+    });
+
+    expect(min).toEqual(0);
+    expect(max).toEqual(50);
+  });
+
+  it('allows moving child that is smaller than contain inside container', () => {
+    const [min, max] = getOffsetBounds({
+      containerDimension: 200,
+      childDimension: 100,
+      padding: 0
+    });
+
+    expect(min).toEqual(-100);
+    expect(max).toEqual(0);
+  });
+
+  it('allows moving far enough to reveal padding', () => {
+    const [min, max] = getOffsetBounds({
+      containerDimension: 100,
+      childDimension: 150,
+      padding: 10
+    });
+
+    expect(min).toEqual(-10);
+    expect(max).toEqual(60);
+  });
+
+  it('allows revealing padding even if container and child have same dimension', () => {
+    const [min, max] = getOffsetBounds({
+      containerDimension: 100,
+      childDimension: 100,
+      padding: 10
+    });
+
+    expect(min).toEqual(-10);
+    expect(max).toEqual(10);
+  });
+
+  it('ignores padding if child including padding is smaller than container', () => {
+    const [min, max] = getOffsetBounds({
+      containerDimension: 200,
+      childDimension: 100,
+      padding: 10
+    });
+
+    expect(min).toEqual(-100);
+    expect(max).toEqual(0);
+  });
+
+  it('allows revealing padding even if child and one padding fits container', () => {
+    const [min, max] = getOffsetBounds({
+      containerDimension: 200,
+      childDimension: 190,
+      padding: 10
+    });
+
+    expect(min).toEqual(-10);
+    expect(max).toEqual(0);
+  });
+
+  it('allows revealing padding even if child without padding is smaller than container', () => {
+    const [min, max] = getOffsetBounds({
+      containerDimension: 200,
+      childDimension: 190,
+      padding: 20
+    });
+
+    expect(min).toEqual(-20);
+    expect(max).toEqual(10);
+  });
+});

--- a/src/PinchZoom/component.tsx
+++ b/src/PinchZoom/component.tsx
@@ -551,6 +551,7 @@ class PinchZoom extends React.Component<Props> {
 
   private _sanitize() {
     if (this._zoomFactor < this.props.zoomOutFactor) {
+      this._resetInertia();
       this._zoomOutAnimation();
     } else if (this._isInsaneOffset()) {
       this._sanitizeOffsetAnimation();

--- a/src/PinchZoom/component.tsx
+++ b/src/PinchZoom/component.tsx
@@ -4,11 +4,12 @@ import { styleRoot, styleChild, styles } from './styles.css';
 import { Interaction, Point } from '../types';
 import { isTouch } from '../utils';
 import { AnimateOptions, ScaleToOptions, Props, DefaultProps } from './types';
+import { getOffsetBounds } from './getOffsetBounds';
 
 const classnames = (base: string, other?: string): string =>
   other ? `${base} ${other}` : base;
 
-const { abs, max, min, sqrt } = Math;
+const { abs, min, sqrt } = Math;
 
 const isSsr = typeof window === 'undefined';
 
@@ -358,12 +359,18 @@ class PinchZoom extends React.Component<Props> {
     const { width, height } = this._getChildSize();
     const elWidth = width * this._getInitialZoomFactor() * this._zoomFactor;
     const elHeight = height * this._getInitialZoomFactor() * this._zoomFactor;
-    const maxX = elWidth - rect.width + this.props.horizontalPadding;
-    const maxY = elHeight - rect.height + this.props.verticalPadding;
-    const maxOffsetX = max(maxX, 0);
-    const maxOffsetY = max(maxY, 0);
-    const minOffsetX = min(maxX, 0) - this.props.horizontalPadding;
-    const minOffsetY = min(maxY, 0) - this.props.verticalPadding;
+
+    const [minOffsetX, maxOffsetX] = getOffsetBounds({
+      containerDimension: rect.width,
+      childDimension: elWidth,
+      padding: this.props.horizontalPadding
+    });
+
+    const [minOffsetY, maxOffsetY] = getOffsetBounds({
+      containerDimension: rect.height,
+      childDimension: elHeight,
+      padding: this.props.verticalPadding
+    })
 
     return {
       x: clamp(minOffsetX, maxOffsetX, offset.x),

--- a/src/PinchZoom/component.tsx
+++ b/src/PinchZoom/component.tsx
@@ -109,6 +109,7 @@ class PinchZoom extends React.Component<Props> {
     animationDuration: 250,
     draggableUnZoomed: true,
     enforceBoundsDuringZoom: false,
+    centerContained: false,
     enabled: true,
     inertia: true,
     inertiaFriction: 0.96,
@@ -363,13 +364,15 @@ class PinchZoom extends React.Component<Props> {
     const [minOffsetX, maxOffsetX] = getOffsetBounds({
       containerDimension: rect.width,
       childDimension: elWidth,
-      padding: this.props.horizontalPadding
+      padding: this.props.horizontalPadding,
+      centerContained: this.props.centerContained
     });
 
     const [minOffsetY, maxOffsetY] = getOffsetBounds({
       containerDimension: rect.height,
       childDimension: elHeight,
-      padding: this.props.verticalPadding
+      padding: this.props.verticalPadding,
+      centerContained: this.props.centerContained
     })
 
     return {
@@ -1061,6 +1064,7 @@ if (process.env.NODE_ENV !== 'production') {
     animationDuration: number,
     draggableUnZoomed: bool,
     enforceBoundsDuringZoom: bool,
+    centerContained: bool,
     enabled: bool,
     horizontalPadding: number,
     lockDragAxis: bool,

--- a/src/PinchZoom/component.tsx
+++ b/src/PinchZoom/component.tsx
@@ -471,6 +471,7 @@ class PinchZoom extends React.Component<Props> {
 
   private _scaleTo(zoomFactor: number, center: Point) {
     this._scale(zoomFactor / this._zoomFactor, center);
+    this._offset = this._sanitizeOffset(this._offset);
   }
 
   private _scale(scale: number, center: Point) {

--- a/src/PinchZoom/getOffsetBounds.ts
+++ b/src/PinchZoom/getOffsetBounds.ts
@@ -1,14 +1,19 @@
 import { OffsetBoundsOptions } from './types';
 
+const {min, max} = Math;
+
 export function getOffsetBounds({
   containerDimension,
   childDimension,
-  padding
+  padding,
+  centerContained
 }: OffsetBoundsOptions) {
-  const max = childDimension - containerDimension + padding;
+  const diff = childDimension - containerDimension;
 
-  const maxOffset = Math.max(max, 0);
-  const minOffset = Math.min(max, 0) - padding;
-
-  return [minOffset, maxOffset];
+  if (diff + 2 * padding <= 0 && centerContained) {
+    return [diff / 2, diff / 2]
+  }
+  else {
+    return [min(diff + padding, 0) - padding, max(0, diff + padding)]
+  }
 }

--- a/src/PinchZoom/getOffsetBounds.ts
+++ b/src/PinchZoom/getOffsetBounds.ts
@@ -1,0 +1,14 @@
+import { OffsetBoundsOptions } from './types';
+
+export function getOffsetBounds({
+  containerDimension,
+  childDimension,
+  padding
+}: OffsetBoundsOptions) {
+  const max = childDimension - containerDimension + padding;
+
+  const maxOffset = Math.max(max, 0);
+  const minOffset = Math.min(max, 0) - padding;
+
+  return [minOffset, maxOffset];
+}

--- a/src/PinchZoom/types.ts
+++ b/src/PinchZoom/types.ts
@@ -20,6 +20,12 @@ export interface ScaleToOptions {
   duration?: number;
 }
 
+export interface OffsetBoundsOptions {
+  childDimension: number;
+  containerDimension: number;
+  padding: number;
+}
+
 export interface DefaultProps {
   shouldInterceptWheel: (e: WheelEvent) => boolean;
   shouldCancelHandledTouchEndEvents: boolean;

--- a/src/PinchZoom/types.ts
+++ b/src/PinchZoom/types.ts
@@ -24,6 +24,7 @@ export interface OffsetBoundsOptions {
   childDimension: number;
   containerDimension: number;
   padding: number;
+  centerContained?: boolean;
 }
 
 export interface DefaultProps {
@@ -34,6 +35,7 @@ export interface DefaultProps {
   wheelScaleFactor: number;
   draggableUnZoomed: boolean;
   enforceBoundsDuringZoom: boolean;
+  centerContained: boolean;
   inertia: boolean;
   inertiaFriction: number;
   enabled: boolean;


### PR DESCRIPTION
So far, when external styles force the container to be larger than the child, `_sanitizeOffset` always allowed moving the child inside the container:

https://github.com/retyui/react-quick-pinch-zoom/assets/26554/fa41b90c-74ac-4d1f-b7d5-640c4d39ad4f

Especially on portrait screens it can make sense to use a viewport sized container. A landscape image will initially be centered and scaled to fit into the container. Once the image is zoomed the whole viewport can be used to view the image.

As long as the image still fits into the viewport vertically, it does not make sense to allow moving it vertically. There already is a prop `draggableUnZoomed` which prevents dragging the image while it has not been zoomed. Soon as the image has only slightly been zoomed, it can again be moved out of the center vertically.

This commit adds a `centerContained` prop to allow ensuring that images remain centered as long as they still fit into the container.

This PR contains commits that perform the following steps:

* Extract previous `_sanitizeOffset` logic into a separate function unchanged and cover it with tests
* Add `centerContained` prop. Tests make sure new implementation does not change behavior in previous cases
* Fix some edge cases that only come up when the container is larger than the image

Finally, `yarn size` started failing since the changes pushed us over the limit. So far tests were also considered in the total size, which does not make sense, I think. So I ignored those to push us under the limit. Not sure if the limit is a specifically chosen target site or if it is just about noticing when the code gets bigger.

