### PR TITLE
Turn tslib from peer dependency into dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,19 +4,18 @@
   "main": "cmj/index.js",
   "module": "esm/index.js",
   "types": "esm/index.d.ts",
+  "dependencies": {
+    "tslib": ">=2.0.0"
+  },
   "peerDependencies": {
     "react": ">=16.4.0",
-    "react-dom": ">=16.4.0",
-    "tslib": ">=2.0.0"
+    "react-dom": ">=16.4.0"
   },
   "peerDependenciesMeta": {
     "react": {
       "optional": true
     },
     "react-dom": {
-      "optional": true
-    },
-    "tslib": {
       "optional": true
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4370,10 +4370,10 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
-tslib@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
-  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
+tslib@>=2.0.0:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.2.tgz#1b6f07185c881557b0ffa84b111a0106989e8338"
+  integrity sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==
 
 type-check@~0.3.2:
   version "0.3.2"


### PR DESCRIPTION
`importHelpers: true` is present in `tsconfig.json` which causes helpers to be imported from `tslib`, but if the surrounding project does not use TypeScript, the package will not be present. This also makes it possible to use libraries that depend on incompatible versions of `tslib`.

Fixes #74