### PR TITLE
Fix: inconsistent zooms in different screen-sizes

### DIFF
--- a/src/PinchZoom/component.tsx
+++ b/src/PinchZoom/component.tsx
@@ -382,11 +382,15 @@ class PinchZoom extends React.Component<Props> {
   }
 
   alignCenter(options: ScaleToOptions) {
-    const { x, y, scale, animated, duration } = {
+    const { x: __x, y: __y, scale, animated, duration } = {
       duration: 250,
       animated: true,
       ...options,
     };
+    
+    // Bug-Fix: https://github.com/retyui/react-quick-pinch-zoom/issues/58
+    const x = __x * this._initialZoomFactor;
+    const y = __y * this._initialZoomFactor;
 
     const startZoomFactor = this._zoomFactor;
     const startOffset = { ...this._offset };


### PR DESCRIPTION
Bug: https://github.com/retyui/react-quick-pinch-zoom/issues/58
Demo: https://codesandbox.io/s/react-quick-pinch-fix-58-5wfgm6?file=/src/App.js:927-1635
How to re-create issue:
1. Open 2 new separate preview windows from above sandbox
2. Open Developer Tools in only one preview window. This is to change width of view port. Any other means to change view port can be also used.
3. Toggle value of `const doInConsistentZoom = false;` near line no-28.
    a. For  `const doInConsistentZoom = true;` both different sized window will zoom in and align at different points.
    b. For  `const doInConsistentZoom = false;` both different sized window will zoom in and align at same points.