### PR TITLE
Add CSP nonce prop

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -23,6 +23,7 @@
   - [`draggableUnZoomed?: boolean`](#draggableunzoomed-boolean)
   - [`doubleTapZoomOutOnMaxScale?: boolean`](#doubletapzoomoutonmaxscale-boolean-1)
   - [`lockDragAxis?: boolean`](#lockdragaxis-boolean)
+  - [`nonce?: string`](#nonce-string)
   - [`setOffsetsOnce?: boolean`](#setoffsetsonce-boolean)
   - [`verticalPadding?: number`](#verticalpadding-number)
   - [`horizontalPadding?: number`](#horizontalpadding-number)
@@ -64,6 +65,7 @@ import QuickPinchZoom from "react-quick-pinch-zoom";
   doubleTapZoomOutOnMaxScale={false}
   doubleTapToggleZoom={false}
   lockDragAxis={false}
+  nonce={undefined}
   setOffsetsOnce={false}
   verticalPadding={0}
   horizontalPadding={0}
@@ -212,6 +214,12 @@ Using `false` allows other libs to pick up drag events
 Lock panning of the element to a single axis.
 
 (default `false`)
+
+## `nonce?: string`
+
+Optional CSP nonce for injecting required CSS into the document.
+
+(default `undefined`)
 
 ## `setOffsetsOnce?: boolean`
 

--- a/src/PinchZoom/component.tsx
+++ b/src/PinchZoom/component.tsx
@@ -1046,13 +1046,13 @@ class PinchZoom extends Component<Props> {
   }
 
   render() {
-    const { children, containerProps } = this.props;
+    const { children, containerProps, nonce } = this.props;
     const child = Children.only(children);
     const props = containerProps || {};
 
     return (
       <>
-        <style>{styles}</style>
+        <style nonce={nonce}>{styles}</style>
         <div
           {...props}
           ref={this._containerRef}
@@ -1068,7 +1068,7 @@ class PinchZoom extends Component<Props> {
 }
 
 if (process.env.NODE_ENV !== 'production') {
-  const { any, element, object, number, func, bool } = require('prop-types');
+  const { any, element, object, number, func, bool, string } = require('prop-types');
 
   // @ts-ignore
   PinchZoom.propTypes = {
@@ -1082,6 +1082,7 @@ if (process.env.NODE_ENV !== 'production') {
     enabled: bool,
     horizontalPadding: number,
     lockDragAxis: bool,
+    nonce: string,
     onUpdate: func.isRequired,
     maxZoom: number,
     minZoom: number,

--- a/src/PinchZoom/types.ts
+++ b/src/PinchZoom/types.ts
@@ -41,6 +41,7 @@ export interface DefaultProps {
   enabled: boolean;
   horizontalPadding: number;
   lockDragAxis: boolean;
+  nonce?: string;
 
   maxZoom: number;
   minZoom: number;


### PR DESCRIPTION
[Strict CSP rules](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP) can block inline styles added by this library (`style-src-elem`). To prevent this, `nonce` prop allows passing nonce to the `<style>` element, marking it safe for the browser.

Closes #92.